### PR TITLE
Append bundle identifier to cache path

### DIFF
--- a/PodcastMenu/ImageCache.swift
+++ b/PodcastMenu/ImageCache.swift
@@ -26,7 +26,7 @@ final class ImageCache {
         let filebase = imageUrl.path.replacingOccurrences(of: "/", with: "_")
         let filename = filebase + "-" + imageUrl.lastPathComponent
         
-        let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first! + "/" + filename + "-" + imageUrl.lastPathComponent
+        let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first! + "/" + Bundle.main.bundleIdentifier! + "/ImageCache/" + filename + "-" + imageUrl.lastPathComponent
         
         return URL(fileURLWithPath: path)
     }


### PR DESCRIPTION
~/Library/Caches gets polluted without this.

This should fix #22. Note: I've not been able to build the project to test this.