### PR TITLE
Implement automatic refreshing

### DIFF
--- a/PodcastMenu/Constants.swift
+++ b/PodcastMenu/Constants.swift
@@ -18,4 +18,5 @@ struct Constants {
     static let homePath = "/podcasts"
     static let logOutURL = URL(string: "https://overcast.fm/logout")!
     static let mainStyleName = "main.css"
+    static let automaticRefreshInterval = 3600.0
 }

--- a/PodcastMenu/Constants.swift
+++ b/PodcastMenu/Constants.swift
@@ -18,5 +18,5 @@ struct Constants {
     static let homePath = "/podcasts"
     static let logOutURL = URL(string: "https://overcast.fm/logout")!
     static let mainStyleName = "main.css"
-    static let automaticRefreshInterval = 3600.0
+    static let automaticRefreshInterval = 900.0
 }

--- a/PodcastMenu/OvercastController.swift
+++ b/PodcastMenu/OvercastController.swift
@@ -42,22 +42,18 @@ class OvercastController: NSObject, WKNavigationDelegate {
     }()
     
      fileprivate func startAutomaticRefresh() {
-        
         Timer.scheduledTimer(timeInterval: TimeInterval(Constants.automaticRefreshInterval), target: self, selector: #selector(self.refresh(timer:)) , userInfo: nil, repeats: true)
         
         NSWorkspace.shared().notificationCenter.addObserver(forName: Notification.Name.NSWorkspaceDidWake, object: NSWorkspace.shared(), queue: nil) { [weak self] _ in
-            
             self?.refreshPodcastsIfNeeded()
         }
     }
     
     @objc fileprivate func refresh(timer: Timer) {
-        
         refreshPodcastsIfNeeded()
     }
         
     fileprivate func refreshPodcastsIfNeeded() {
-        
        guard (activity == nil) else { return }
        guard (self.webView.url != nil) else { return }
        guard self.webView.url?.path == Constants.homePath else { return }

--- a/PodcastMenu/OvercastController.swift
+++ b/PodcastMenu/OvercastController.swift
@@ -62,7 +62,7 @@ class OvercastController: NSObject, WKNavigationDelegate {
        guard (self.webView.url != nil) else { return }
        guard self.webView.url?.path == Constants.homePath else { return }
        guard !self.webView.isLoading else { return }
-       guard !(self.webView.window?.isVisible)! else { return }
+       guard (self.webView.window?.isVisible == false) else { return }
         #if DEBUG
             NSLog("[OvercastController] automatically refreshing podcasts")
         #endif


### PR DESCRIPTION
I noticed that sometimes I would get a notification of my phone from Overcast of a new episode. Upon opening the menu of the application the episode isn't under the *All Active Episodes* section. I know I can manually click on the episode and play the latest episode but I would like to to be just there when I am ready. 
This pull request may sound trivial but I would like to hear your thoughts on it @insidegui 

TODO:

- [x] Implement basic automatic refreshing 
~~Add menu item to turn it on or off~~
~~Add option for user to select refresh interval. e.g. 15 min, 30 min and 1 hour~~

I created a timer that will fire based on the `automaticRefreshInterval`. I also decided that it would be a good idea to refresh anytime the machine wakes up so the user can get latest changes.

Note: I am aware that simply refreshing based on a static amount of time might not solve this issue entirely but I think it will be a good idea.

Btw, thanks @insidegui for creating this 🙂